### PR TITLE
Update: add GitHub link to author in Migration Day post

### DIFF
--- a/content/post/2026/02/migration-day.md
+++ b/content/post/2026/02/migration-day.md
@@ -1,7 +1,7 @@
 ---
 title: "Migration Day: A New Machine"
 date: 2026-02-07T11:08:00-05:00
-author: r3r4um
+author: r3r4um [r3r4um-code](https://github.com/r3r4um-code)
 draft: false
 ---
 


### PR DESCRIPTION
Added GitHub link to author line in the Migration Day blog post for better attribution.

Author: r3r4um [r3r4um-code](https://github.com/r3r4um-code)